### PR TITLE
Attempting to add "Android browser" to UA Family.

### DIFF
--- a/modules/uadetector-core/src/main/java/net/sf/uadetector/UserAgentFamily.java
+++ b/modules/uadetector-core/src/main/java/net/sf/uadetector/UserAgentFamily.java
@@ -229,6 +229,11 @@ public enum UserAgentFamily {
 	ANDROID_WEBKIT("Android Webkit", Pattern.compile("Android Webkit")),
 
 	/**
+	 * Android Browser
+	 */
+	ANDROID_BROWSER("Android browser", Pattern.compile("Android browser")),
+
+	/**
 	 * Anemone
 	 */
 	ANEMONE("Anemone", Pattern.compile("Anemone")),

--- a/modules/uadetector-core/src/test/java/net/sf/uadetector/UserAgentFamilyTest.java
+++ b/modules/uadetector-core/src/test/java/net/sf/uadetector/UserAgentFamilyTest.java
@@ -44,6 +44,11 @@ public class UserAgentFamilyTest {
 	}
 
 	@Test
+	public void evaluate_knownString_ANDROID_BROWSER() {
+		assertThat(UserAgentFamily.evaluate("Android browser")).isEqualTo(UserAgentFamily.ANDROID_BROWSER);
+	}
+
+	@Test
 	public void evaluate_MAILRU() {
 		assertThat(UserAgentFamily.evaluate("Mail.Ru/1.0")).isEqualTo(UserAgentFamily.MAIL_RU);
 		assertThat(UserAgentFamily.evaluate("Mail.RU_Bot/2.0")).isEqualTo(UserAgentFamily.MAIL_RU);


### PR DESCRIPTION
I'm not sure if this fixes the issue https://github.com/before/uadetector/issues/50? I tried testing the change in my application and it did not fix it. But based on my reading of the code in uas.xml there is an browser with the name set to "Android browser" and then in XmlDataHandler the name field is converted into UserAgentFamily. It would be nice if src/test/resources/examples had an integration test for user agent family but that is outside the scope of this bug fix.

Could you take a look at this pull request and see if I did it right? Sorry.
